### PR TITLE
Add current working directory so that jshint can find the proper .jshint rc file to configure linter

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -24,7 +24,8 @@ class LinterJshint extends Linter
     # '\\((?<warning>.).+\\)'
     ')'
 
-  constructor: (editorView)->
+  constructor: (editor)->
+    @cwd = path.dirname(editor.getUri())
     @executablePath = atom.config.get 'linter-jshint.jshintExecutablePath'
 
 module.exports = LinterJshint


### PR DESCRIPTION
jshint needs to be run from the working directory with the edited file so that it can look up through the directory structure to find it's .jshintrc file for configuration.
