### PR TITLE
fix(conf): changed path default config

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -2,4 +2,4 @@ path = require 'path'
 
 module.exports =
   configDefaults:
-    jshintExecutablePath: path.join __dirname, '..', 'node_modules', '.bin'
+    jshintExecutablePath: path.join __dirname, '..', 'node_modules', 'jshint', 'bin'


### PR DESCRIPTION
Changed the default config path, to the binary folder of `jshint` module.
