### PR TITLE
Added json to supported source languages

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -5,7 +5,7 @@ findFile = require "#{linterPath}/lib/util"
 class LinterJshint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js', 'source.js.jquery', 'text.html.basic'] # , 'text.html.twig', 'text.html.erb', 'text.html.ruby']
+  @syntax: ['source.js', 'source.js.jquery', 'text.html.basic', 'source.json'] # , 'text.html.twig', 'text.html.erb', 'text.html.ruby']
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.


### PR DESCRIPTION
Simple change to allow linter-jshint to also lint json. Very helpful addition.
