### PR TITLE
Specify command as array to fix paths with spaces

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -9,7 +9,7 @@ class LinterJshint extends Linter
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
-  cmd: 'jshint --verbose --extract=auto'
+  cmd: ['jshint', '--verbose', '--extract=auto']
 
   linterName: 'jshint'
 
@@ -30,7 +30,7 @@ class LinterJshint extends Linter
 
     config = findFile @cwd, ['.jshintrc']
     if config
-      @cmd += " -c #{config}"
+      @cmd = @cmd.concat ['-c', config]
 
     atom.config.observe 'linter-jshint.jshintExecutablePath', @formatShellCmd
 


### PR DESCRIPTION
This is the second half of a fix for https://github.com/AtomLinter/Linter/issues/116

This will require https://github.com/AtomLinter/Linter/pull/143 to be accepted first.
