### PR TITLE
Ability to customize the jshint executable name

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 module.exports =
   configDefaults:
     jshintExecutablePath: path.join __dirname, '..', 'node_modules', 'jshint', 'bin'
+    jshintExecutable: 'jshint'
 
   activate: ->
     console.log 'activate linter-jshint'

--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -7,10 +7,6 @@ class LinterJshint extends Linter
   # list/tuple of strings. Names should be all lowercase.
   @syntax: ['source.js', 'source.js.jquery', 'text.html.basic']
 
-  # A string, list, tuple or callable that returns a string, list or tuple,
-  # containing the command line (with arguments) used to lint.
-  cmd: 'jshint --verbose --extract=auto'
-
   linterName: 'jshint'
 
   # A regex pattern used to extract information from the executable's output.
@@ -28,14 +24,18 @@ class LinterJshint extends Linter
   constructor: (editor) ->
     super(editor)
 
-    config = findFile @cwd, ['.jshintrc']
-    if config
-      @cmd += " -c #{config}"
-
     atom.config.observe 'linter-jshint.jshintExecutablePath', @formatShellCmd
+    atom.config.observe 'linter-jshint.jshintExecutable', @formatShellCmd
+
+    @formatShellCmd()
 
   formatShellCmd: =>
     jshintExecutablePath = atom.config.get 'linter-jshint.jshintExecutablePath'
+    jshintExecutable = atom.config.get 'linter-jshint.jshintExecutable'
+    @cmd = "#{jshintExecutable} --verbose --extract=auto"
+    config = findFile @cwd, ['.jshintrc']
+    if config
+      @cmd += " -c #{config}"
     @executablePath = "#{jshintExecutablePath}"
 
   destroy: ->


### PR DESCRIPTION
For example, one could use jsxhint thanks to this setting.

![linter-configured-with-jshint](https://cloud.githubusercontent.com/assets/55289/3821941/45691062-1d18-11e4-9976-777926dd2f7d.png)

![linter-configured-with-jsxhint](https://cloud.githubusercontent.com/assets/55289/3821940/45685dde-1d18-11e4-9572-45f22361aa32.png)
