### PR TITLE
Up jshint to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "jshint": "~2.5.0"
+    "jshint": "~2.6.0"
   }
 }


### PR DESCRIPTION
This will remove false-error `A generator function shall contain a yield statement (W124)` that was fixed in `2.6.0` release of jshint.