### PR TITLE
set syntax to only source.js

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -5,7 +5,7 @@ Linter = require "#{linterPath}/lib/linter"
 class LinterJshint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: ['source.js', 'source.js.jquery', 'text.html.basic']
+  @syntax: 'source.js'
 
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.


### PR DESCRIPTION
Set the syntax to only source.js since .html or .js.jquery aren't standard file types.\

This should fix Issues #21 and #20. 