### PR TITLE
Disable linting when no `.jshintrc` file is present

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -7,5 +7,10 @@ module.exports =
       title: 'JSHint Executable Path'
       type: 'string'
 
+    disableWhenNoJshintrcFileInPath:
+      default: false
+      title: 'Disable when no .jshintrc file found in path'
+      type: 'boolean'
+
   activate: ->
     console.log 'activate linter-jshint'

--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -7,6 +7,8 @@ class LinterJshint extends Linter
   # list/tuple of strings. Names should be all lowercase.
   @syntax: 'source.js'
 
+  disableWhenNoJshintrcFileInPath: false
+
   # A string, list, tuple or callable that returns a string, list or tuple,
   # containing the command line (with arguments) used to lint.
   cmd: ['jshint', '--verbose', '--extract=auto']
@@ -41,6 +43,16 @@ class LinterJshint extends Linter
 
     atom.config.observe 'linter-jshint.jshintExecutablePath', @formatShellCmd
 
+    atom.config.observe 'linter-jshint.disableWhenNoJshintrcFileInPath',
+      (skipNonJshint) =>
+        @disableWhenNoJshintrcFileInPath = skipNonJshint
+
+  lintFile: (filePath, callback) ->
+    if not @config and @disableWhenNoJshintrcFileInPath
+      return
+
+    super(filePath, callback)
+
   formatShellCmd: =>
     jshintExecutablePath = atom.config.get 'linter-jshint.jshintExecutablePath'
     @executablePath = "#{jshintExecutablePath}"
@@ -53,5 +65,7 @@ class LinterJshint extends Linter
 
   destroy: ->
     atom.config.unobserve 'linter-jshint.jshintExecutablePath'
+
+    atom.config.unobserve 'linter-jshint.disableWhenNoJshintrcFileInPath'
 
 module.exports = LinterJshint


### PR DESCRIPTION
Add a `disableWhenNoJshintrcFileInPath` option that disables jshint linting when there is no `.jshintrc` file found.

This allows `linter-jshint` to be installed but not lint directory trees where another linter, such as `linter-eslint` is being used instead.

This is similar to the option in https://github.com/AtomLinter/linter-eslint.