### PR TITLE
This should fix #60/#67/#68 and #59/#66, i. e. "Package.getActivationCom...

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,8 +1,11 @@
 path = require 'path'
 
 module.exports =
-  configDefaults:
-    jshintExecutablePath: path.join __dirname, '..', 'node_modules', 'jshint', 'bin'
+  config:
+    jshintExecutablePath:
+      default: path.join __dirname, '..', 'node_modules', 'jshint', 'bin'
+      title: 'JSHint Executable Path'
+      type: 'string'
 
   activate: ->
     console.log 'activate linter-jshint'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-jshint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": {},
   "version": "0.1.2",
   "description": "Linter plugin for JavaScript, using jshint",
   "repository": "https://github.com/AtomLinter/linter-jshint.git",


### PR DESCRIPTION
...mands is deprecated" and "Package.activateConfig is deprecated".

I used and adjusted the changes from https://github.com/AtomLinter/linter-csslint, so it should work without a problem (I didn't encounter any problems yet).