### PR TITLE
Using activationCommands instead of activationEvents in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "linter-jshint",
   "main": "./lib/init",
   "linter-package": true,
-  "activationCommands": {},
+  "activationEvents": {},
   "version": "0.1.2",
   "description": "Linter plugin for JavaScript, using jshint",
   "repository": "https://github.com/AtomLinter/linter-jshint.git",


### PR DESCRIPTION
This change is required to stop the Atom deprecate warning, as mentioned at issue #78.