### PR TITLE
Move atom.config observer to disposables container

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -45,8 +45,7 @@ class LinterJshint extends Linter
       @cmd = @cmd.concat ['--exclude-path', ignore]
 
     @disposables.add atom.config.observe 'linter-jshint.jshintExecutablePath', @formatShellCmd
-
-    atom.config.observe 'linter-jshint.disableWhenNoJshintrcFileInPath',
+    @disposables.add atom.config.observe 'linter-jshint.disableWhenNoJshintrcFileInPath',
       (skipNonJshint) =>
         @disableWhenNoJshintrcFileInPath = skipNonJshint
 
@@ -68,7 +67,5 @@ class LinterJshint extends Linter
 
   destroy: ->
     @disposables.dispose()
-
-    atom.config.unobserve 'linter-jshint.disableWhenNoJshintrcFileInPath'
 
 module.exports = LinterJshint


### PR DESCRIPTION
Fixes #76 and takes advantage of the CompositeDisposable container so there is no need to use extra variables. Neat :-)

Not sure how to test (to trigger the deactivate event), but I opened and closed a few js files to see if there were any errors popping up. Please let me know if this patch is still missing something :-)

Edit: also fixes #80