### PR TITLE
defines config as a property instead of a variable

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -36,10 +36,10 @@ class LinterJshint extends Linter
 
     @disposables = new CompositeDisposable
 
-    config = findFile @cwd, ['.jshintrc']
+    @config = findFile @cwd, ['.jshintrc']
     ignore = findFile @cwd, ['.jshintignore']
-    if config
-      @cmd = @cmd.concat ['-c', config]
+    if @config
+      @cmd = @cmd.concat ['-c', @config]
 
     if ignore
       @cmd = @cmd.concat ['--exclude-path', ignore]


### PR DESCRIPTION
since the `config` wasn't a property was impossible to access it in the method `lintFile`

Fixes #40 
Fixes #100 