### PR TITLE
add source.js.jsx syntax

### DIFF
--- a/lib/linter-jshint.coffee
+++ b/lib/linter-jshint.coffee
@@ -6,7 +6,7 @@ Linter = require "#{linterPath}/lib/linter"
 class LinterJshint extends Linter
   # The syntax that the linter handles. May be a string or
   # list/tuple of strings. Names should be all lowercase.
-  @syntax: 'source.js'
+  @syntax: ['source.js', 'source.js.jsx']
 
   disableWhenNoJshintrcFileInPath: false
 


### PR DESCRIPTION
makes it possible to use linting with https://atom.io/packages/language-babel

I'm relatively new to Atom, but this seems to work for me. Thoughts?