### PR TITLE
Add `disableWhenNoJshintrcFileInPath` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You can configure linter-jshint by editing ~/.atom/config.cson (choose Open Your
   executablePath: '/path/to/bundled/jshint'
   # Lint JavaScript inside `<script>` blocks in HTML or PHP files
   lintInlineJavaScript: false
+  # Disable linter when no `.jshintrc` is found in project
+  disableWhenNoJshintrcFileInPath: false
 ```
 
 ## Contributing

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,6 +11,10 @@ module.exports =
       type: 'boolean'
       default: false
       description: 'Lint JavaScript inside `<script>` blocks in HTML or PHP files.'
+    disableWhenNoJshintrcFileInPath:
+      type: 'boolean'
+      default: false
+      description: 'Disable linter when no `.jshintrc` is found in project.'
 
   activate: ->
     @subscriptions = new CompositeDisposable
@@ -38,6 +42,11 @@ module.exports =
       lintOnFly: true
       lint: (textEditor) =>
         filePath = textEditor.getPath()
+
+        if atom.config.get('linter-jshint.disableWhenNoJshintrcFileInPath')
+          if !helpers.findFile(filePath, '.jshintrc')
+            return []
+
         text = textEditor.getText()
         parameters = ['--reporter', reporter, '--filename', filePath]
         if textEditor.getGrammar().scopeName.indexOf('text.html') isnt -1 and 'source.js.embedded.html' in @scopes


### PR DESCRIPTION
Allows linter to be disabled if no jshintrc file is in project.

This is mostly lifted from [linter-eslint](https://github.com/AtomLinter/linter-eslint/blob/master/lib/linter-eslint.coffee#L59-62).