### PR TITLE
Add back a guard for the HTML JS extraction

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -101,7 +101,9 @@ module.exports = {
             return results
           }
         }
-        if (this.lintInlineJavaScript) {
+        if (this.lintInlineJavaScript &&
+          textEditor.getGrammar().scopeName.indexOf('text.html') !== -1
+        ) {
           parameters.push('--extract', 'always')
         }
         parameters.push('-')


### PR DESCRIPTION
It seems that the JS extraction code is incredibly buggy in JSHint, leading to the results being very wrong when it is run on pure JS code.
Before v2.0.0 this check existed to ensure it only ran on HTML code, but was mistakenly removed in v2.0.0.

Fixes #214.