### PR TITLE
Don't go negative on line/col

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -129,14 +129,14 @@ module.exports = {
 
           const error = entry.error
           const errorType = error.code.substr(0, 1)
-          const errorLine = error.line - 1
+          const errorLine = error.line > 0 ? error.line - 1 : 0
           let range
 
           // TODO: Remove workaround of jshint/jshint#2846
           if (error.character === null) {
             range = Helpers.rangeFromLineNumber(textEditor, errorLine)
           } else {
-            let character = error.character
+            let character = error.character > 0 ? error.character - 1 : 0
             // TODO: Remove workaround of jquery/esprima#1457
             const maxCharacter = textEditor.getBuffer().lineLengthForRow(errorLine)
             if (character > maxCharacter) {


### PR DESCRIPTION
Ensure that the line and column aren't negative before calling Atom APIs.

Also fixes an off-by-one bug in the column.

Fixes #213.