### PR TITLE
Pin eslint to v2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "jshint-json": "^1.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "babel-eslint": "^5.0.0",
     "eslint-config-airbnb": "^6.1.0"
   },


### PR DESCRIPTION
Pin the version of eslint until the conflict with babel-eslint is resolved.