### PR TITLE
Workaround jshint#2894

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -137,12 +137,19 @@ module.exports = {
             range = Helpers.rangeFromLineNumber(textEditor, errorLine)
           } else {
             let character = error.character > 0 ? error.character - 1 : 0
+            let line = errorLine
+            const buffer = textEditor.getBuffer()
+            const maxLine = buffer.getLineCount()
+            // TODO: Remove workaround of jshint/jshint#2894
+            if (errorLine >= maxLine) {
+              line = maxLine
+            }
+            const maxCharacter = buffer.lineLengthForRow(line)
             // TODO: Remove workaround of jquery/esprima#1457
-            const maxCharacter = textEditor.getBuffer().lineLengthForRow(errorLine)
             if (character > maxCharacter) {
               character = maxCharacter
             }
-            range = Helpers.rangeFromLineNumber(textEditor, errorLine, character)
+            range = Helpers.rangeFromLineNumber(textEditor, line, character)
           }
 
           results.push({


### PR DESCRIPTION
Apparently it can specify a line that is past the end of the file.

Closes #232.