### PR TITLE
Remove JSX Support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,11 +24,6 @@ module.exports = {
       default: false,
       description: 'Disable linter when no `.jshintrc` is found in project.'
     },
-    lintJSXFiles: {
-      title: 'Lint JSX Files',
-      type: 'boolean',
-      default: false
-    },
     jshintFileName: {
       type: 'string',
       default: '.jshintrc',
@@ -54,16 +49,6 @@ module.exports = {
 
     this.subscriptions.add(atom.config.observe('linter-jshint.jshintFileName', (jshintFileName) => {
       this.jshintFileName = jshintFileName
-    }))
-
-    const scopeJSX = 'source.js.jsx'
-    this.subscriptions.add(atom.config.observe('linter-jshint.lintJSXFiles', (lintJSXFiles) => {
-      this.lintJSXFiles = lintJSXFiles
-      if (lintJSXFiles) {
-        this.scopes.push(scopeJSX)
-      } else if (this.scopes.indexOf(scopeJSX) !== -1) {
-        this.scopes.splice(this.scopes.indexOf(scopeJSX), 1)
-      }
     }))
 
     const scopeEmbedded = 'source.js.embedded.html'


### PR DESCRIPTION
JSHint itself makes no claims as to being able to support JSX. If it did in the past, the functionality is no longer there. Please use ESLint with the appropriate parser + plugins if you need JSX support.

Fixes #331.