### PR TITLE
Update eslint to v3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.3",
-    "eslint": "^3.2.2",
+    "eslint": "^3.5.0",
     "eslint-config-airbnb-base": "^7.1.0",
     "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^1.12.0"


### PR DESCRIPTION
This is a peerDependency of eslint-config-airbnb-base that was missed in #334.