### PR TITLE
Fix a race condition

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -105,6 +105,12 @@ module.exports = {
         const result = await Helpers.execNode(
           this.executablePath, parameters, execOpts
         )
+
+        if (textEditor.getText() !== fileContents) {
+          // File has changed since the lint was triggered, tell Linter not to update
+          return null
+        }
+
         let parsed
         try {
           parsed = JSON.parse(result)


### PR DESCRIPTION
Prevent trying to mark up a file with the results when it has changed
since the lint was triggered. This could lead to false positives on the
"invalid position" check. This won't stop issues from being shown as the
edits will have triggered their own `lint()` call.