### PR TITLE
Update and pin JSHint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "atom-linter": "^8.0.0",
     "atom-package-deps": "^4.0.1",
-    "jshint": "^2.9.2",
+    "jshint": "2.9.3",
     "jshint-json": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Users were being left with an out of date version with no simple way to
update.

Fixes #353.