### PR TITLE
Update to eslint-config-airbnb-base v11.0.0

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -122,9 +122,11 @@ module.exports = {
           return results
         }
 
-        for (const entry of parsed.result) {
+        Object.keys(parsed.result).forEach((entryID) => {
+          const entry = parsed.result[entryID]
+
           if (!entry.error.id) {
-            continue
+            return
           }
 
           const error = entry.error
@@ -158,7 +160,7 @@ module.exports = {
             filePath,
             range
           })
-        }
+        })
         return results
       }
     }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,10 @@
-'use babel'
+'use babel';
 
 /* @flow */
 
-import Path from 'path'
+import Path from 'path';
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
-import { CompositeDisposable } from 'atom'
+import { CompositeDisposable } from 'atom';
 
 type Linter$Provider = Object
 
@@ -13,65 +13,65 @@ module.exports = {
     executablePath: {
       type: 'string',
       default: Path.join(__dirname, '..', 'node_modules', 'jshint', 'bin', 'jshint'),
-      description: 'Path of the `jshint` node script'
+      description: 'Path of the `jshint` node script',
     },
     lintInlineJavaScript: {
       type: 'boolean',
       default: false,
-      description: 'Lint JavaScript inside `<script>` blocks in HTML or PHP files.'
+      description: 'Lint JavaScript inside `<script>` blocks in HTML or PHP files.',
     },
     disableWhenNoJshintrcFileInPath: {
       type: 'boolean',
       default: false,
-      description: 'Disable linter when no `.jshintrc` is found in project.'
+      description: 'Disable linter when no `.jshintrc` is found in project.',
     },
     jshintFileName: {
       type: 'string',
       default: '.jshintrc',
-      description: 'jshint file name'
-    }
+      description: 'jshint file name',
+    },
   },
 
   activate() {
-    require('atom-package-deps').install('linter-jshint')
+    require('atom-package-deps').install('linter-jshint');
 
-    this.scopes = ['source.js', 'source.js-semantic']
-    this.subscriptions = new CompositeDisposable()
+    this.scopes = ['source.js', 'source.js-semantic'];
+    this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-jshint.executablePath', (executablePath) => {
-      this.executablePath = executablePath
-    }))
+      this.executablePath = executablePath;
+    }));
     this.subscriptions.add(
       atom.config.observe('linter-jshint.disableWhenNoJshintrcFileInPath',
         (disableWhenNoJshintrcFileInPath) => {
-          this.disableWhenNoJshintrcFileInPath = disableWhenNoJshintrcFileInPath
-        }
-      )
-    )
+          this.disableWhenNoJshintrcFileInPath = disableWhenNoJshintrcFileInPath;
+        },
+      ),
+    );
 
     this.subscriptions.add(atom.config.observe('linter-jshint.jshintFileName', (jshintFileName) => {
-      this.jshintFileName = jshintFileName
-    }))
+      this.jshintFileName = jshintFileName;
+    }));
 
-    const scopeEmbedded = 'source.js.embedded.html'
+    const scopeEmbedded = 'source.js.embedded.html';
     this.subscriptions.add(atom.config.observe('linter-jshint.lintInlineJavaScript',
       (lintInlineJavaScript) => {
-        this.lintInlineJavaScript = lintInlineJavaScript
+        this.lintInlineJavaScript = lintInlineJavaScript;
         if (lintInlineJavaScript) {
-          this.scopes.push(scopeEmbedded)
+          this.scopes.push(scopeEmbedded);
         } else if (this.scopes.indexOf(scopeEmbedded) !== -1) {
-          this.scopes.splice(this.scopes.indexOf(scopeEmbedded), 1)
+          this.scopes.splice(this.scopes.indexOf(scopeEmbedded), 1);
         }
-      }
-    ))
+      },
+    ));
   },
 
   deactivate() {
-    this.subscriptions.dispose()
+    this.subscriptions.dispose();
   },
 
   provideLinter(): Linter$Provider {
-    const Helpers = require('atom-linter')
-    const Reporter = require('jshint-json')
+    const Helpers = require('atom-linter');
+    const Reporter = require('jshint-json');
 
     return {
       name: 'JSHint',
@@ -79,97 +79,97 @@ module.exports = {
       scope: 'file',
       lintOnFly: true,
       lint: async (textEditor) => {
-        const results = []
-        const filePath = textEditor.getPath()
-        const fileContents = textEditor.getText()
-        const parameters = ['--reporter', Reporter, '--filename', filePath]
+        const results = [];
+        const filePath = textEditor.getPath();
+        const fileContents = textEditor.getText();
+        const parameters = ['--reporter', Reporter, '--filename', filePath];
 
         const configFile = await Helpers.findCachedAsync(
-          Path.dirname(filePath), this.jshintFileName
-        )
+          Path.dirname(filePath), this.jshintFileName,
+        );
 
         if (configFile) {
-          parameters.push('--config', configFile)
+          parameters.push('--config', configFile);
         } else if (this.disableWhenNoJshintrcFileInPath) {
-          return results
+          return results;
         }
 
         if (this.lintInlineJavaScript &&
           textEditor.getGrammar().scopeName.indexOf('text.html') !== -1
         ) {
-          parameters.push('--extract', 'always')
+          parameters.push('--extract', 'always');
         }
-        parameters.push('-')
+        parameters.push('-');
 
-        const execOpts = { stdin: fileContents, ignoreExitCode: true }
+        const execOpts = { stdin: fileContents, ignoreExitCode: true };
         const result = await Helpers.execNode(
-          this.executablePath, parameters, execOpts
-        )
+          this.executablePath, parameters, execOpts,
+        );
 
         if (textEditor.getText() !== fileContents) {
           // File has changed since the lint was triggered, tell Linter not to update
-          return null
+          return null;
         }
 
-        let parsed
+        let parsed;
         try {
-          parsed = JSON.parse(result)
+          parsed = JSON.parse(result);
         } catch (_) {
           // eslint-disable-next-line no-console
-          console.error('[Linter-JSHint]', _, result)
+          console.error('[Linter-JSHint]', _, result);
           atom.notifications.addWarning('[Linter-JSHint]',
-            { detail: 'JSHint return an invalid response, check your console for more info' }
-          )
-          return results
+            { detail: 'JSHint return an invalid response, check your console for more info' },
+          );
+          return results;
         }
 
         Object.keys(parsed.result).forEach((entryID) => {
-          const entry = parsed.result[entryID]
+          const entry = parsed.result[entryID];
 
           if (!entry.error.id) {
-            return
+            return;
           }
 
-          const error = entry.error
-          const errorType = error.code.substr(0, 1)
-          let type = 'Info'
+          const error = entry.error;
+          const errorType = error.code.substr(0, 1);
+          let type = 'Info';
           if (errorType === 'E') {
-            type = 'Error'
+            type = 'Error';
           } else if (errorType === 'W') {
-            type = 'Warning'
+            type = 'Warning';
           }
-          const errorLine = error.line > 0 ? error.line - 1 : 0
-          let range
+          const errorLine = error.line > 0 ? error.line - 1 : 0;
+          let range;
 
           // TODO: Remove workaround of jshint/jshint#2846
           if (error.character === null) {
-            range = Helpers.rangeFromLineNumber(textEditor, errorLine)
+            range = Helpers.rangeFromLineNumber(textEditor, errorLine);
           } else {
-            let character = error.character > 0 ? error.character - 1 : 0
-            let line = errorLine
-            const buffer = textEditor.getBuffer()
-            const maxLine = buffer.getLineCount()
+            let character = error.character > 0 ? error.character - 1 : 0;
+            let line = errorLine;
+            const buffer = textEditor.getBuffer();
+            const maxLine = buffer.getLineCount();
             // TODO: Remove workaround of jshint/jshint#2894
             if (errorLine >= maxLine) {
-              line = maxLine
+              line = maxLine;
             }
-            const maxCharacter = buffer.lineLengthForRow(line)
+            const maxCharacter = buffer.lineLengthForRow(line);
             // TODO: Remove workaround of jquery/esprima#1457
             if (character > maxCharacter) {
-              character = maxCharacter
+              character = maxCharacter;
             }
-            range = Helpers.rangeFromLineNumber(textEditor, line, character)
+            range = Helpers.rangeFromLineNumber(textEditor, line, character);
           }
 
           results.push({
             type,
             text: `${error.code} - ${error.reason}`,
             filePath,
-            range
-          })
-        })
-        return results
-      }
-    }
-  }
-}
+            range,
+          });
+        });
+        return results;
+      },
+    };
+  },
+};

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,8 +6,6 @@ import Path from 'path';
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
 
-type Linter$Provider = Object
-
 module.exports = {
   config: {
     executablePath: {
@@ -69,7 +67,7 @@ module.exports = {
     this.subscriptions.dispose();
   },
 
-  provideLinter(): Linter$Provider {
+  provideLinter() {
     const Helpers = require('atom-linter');
     const Reporter = require('jshint-json');
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@
 /* @flow */
 
 import Path from 'path'
-// eslint-disable-next-line import/extensions
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom'
 
 type Linter$Provider = Object
@@ -115,6 +115,7 @@ module.exports = {
         try {
           parsed = JSON.parse(result)
         } catch (_) {
+          // eslint-disable-next-line no-console
           console.error('[Linter-JSHint]', _, result)
           atom.notifications.addWarning('[Linter-JSHint]',
             { detail: 'JSHint return an invalid response, check your console for more info' }
@@ -131,6 +132,12 @@ module.exports = {
 
           const error = entry.error
           const errorType = error.code.substr(0, 1)
+          let type = 'Info'
+          if (errorType === 'E') {
+            type = 'Error'
+          } else if (errorType === 'W') {
+            type = 'Warning'
+          }
           const errorLine = error.line > 0 ? error.line - 1 : 0
           let range
 
@@ -155,7 +162,7 @@ module.exports = {
           }
 
           results.push({
-            type: errorType === 'E' ? 'Error' : errorType === 'W' ? 'Warning' : 'Info',
+            type,
             text: `${error.code} - ${error.reason}`,
             filePath,
             range

--- a/package.json
+++ b/package.json
@@ -19,10 +19,8 @@
     "jshint-json": "^1.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^7.0.0",
     "eslint": "^3.12.0",
     "eslint-config-airbnb-base": "^11.0.0",
-    "eslint-plugin-babel": "^3.3.0",
     "eslint-plugin-import": "^2.2.0"
   },
   "eslintConfig": {
@@ -37,11 +35,7 @@
         }
       ]
     },
-    "plugins": [
-      "babel"
-    ],
     "extends": "airbnb-base",
-    "parser": "babel-eslint",
     "globals": {
       "atom": true
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "test": "apm test",
-    "lint": "eslint lib spec"
+    "lint": "eslint ."
   },
   "package-deps": [
     "linter"
@@ -20,10 +20,10 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",
-    "eslint": "^3.6.0",
-    "eslint-config-airbnb-base": "^8.0.0",
+    "eslint": "^3.12.0",
+    "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-babel": "^3.3.0",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint-plugin-import": "^2.2.0"
   },
   "eslintConfig": {
     "rules": {
@@ -60,7 +60,6 @@
       "atom": true
     },
     "env": {
-      "es6": true,
       "node": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -31,14 +31,11 @@
         "error",
         "never"
       ],
-      "no-console": "off",
-      "no-continue": "off",
       "semi": [
         "error",
         "never"
       ],
       "global-require": "off",
-      "no-nested-ternary": "off",
       "import/no-unresolved": [
         "error",
         {
@@ -46,10 +43,7 @@
             "atom"
           ]
         }
-      ],
-      "import/no-extraneous-dependencies": "off",
-      "arrow-parens": "off",
-      "babel/arrow-parens": "error"
+      ]
     },
     "plugins": [
       "babel"

--- a/package.json
+++ b/package.json
@@ -27,14 +27,6 @@
   },
   "eslintConfig": {
     "rules": {
-      "comma-dangle": [
-        "error",
-        "never"
-      ],
-      "semi": [
-        "error",
-        "never"
-      ],
       "global-require": "off",
       "import/no-unresolved": [
         "error",

--- a/spec/linter-jshint-spec.js
+++ b/spec/linter-jshint-spec.js
@@ -1,101 +1,101 @@
-'use babel'
+'use babel';
 
-import * as path from 'path'
-import linter from '../lib/main'
+import * as path from 'path';
+import linter from '../lib/main';
 
-const bitwisePath = path.join(__dirname, 'fixtures', 'bitwise', 'bitwise.js')
-const syntaxPath = path.join(__dirname, 'fixtures', 'syntax', 'badSyntax.js')
-const emptyPath = path.join(__dirname, 'fixtures', 'empty.js')
-const goodPath = path.join(__dirname, 'fixtures', 'good.js')
+const bitwisePath = path.join(__dirname, 'fixtures', 'bitwise', 'bitwise.js');
+const syntaxPath = path.join(__dirname, 'fixtures', 'syntax', 'badSyntax.js');
+const emptyPath = path.join(__dirname, 'fixtures', 'empty.js');
+const goodPath = path.join(__dirname, 'fixtures', 'good.js');
 
 describe('The JSHint provider for Linter', () => {
-  const lint = linter.provideLinter().lint
+  const lint = linter.provideLinter().lint;
 
   beforeEach(() => {
     waitsForPromise(() =>
-      atom.packages.activatePackage('linter-jshint')
-    )
+      atom.packages.activatePackage('linter-jshint'),
+    );
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-javascript')
-    )
+      atom.packages.activatePackage('language-javascript'),
+    );
     waitsForPromise(() =>
-      atom.workspace.open(bitwisePath)
-    )
-  })
+      atom.workspace.open(bitwisePath),
+    );
+  });
 
   it('should be in the packages list', () =>
-    expect(atom.packages.isPackageLoaded('linter-jshint')).toBe(true)
-  )
+    expect(atom.packages.isPackageLoaded('linter-jshint')).toBe(true),
+  );
 
   it('should be an active package', () =>
-    expect(atom.packages.isPackageActive('linter-jshint')).toBe(true)
-  )
+    expect(atom.packages.isPackageActive('linter-jshint')).toBe(true),
+  );
 
   describe('shows errors in a file with issues', () => {
-    let editor = null
+    let editor = null;
     beforeEach(() => {
       waitsForPromise(() =>
         atom.workspace.open(bitwisePath).then((openEditor) => {
-          editor = openEditor
-        })
-      )
-    })
+          editor = openEditor;
+        }),
+      );
+    });
 
     it('verifies the first message', () => {
-      const message = "W016 - Unexpected use of '&'."
+      const message = "W016 - Unexpected use of '&'.";
       waitsForPromise(() =>
         lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('Warning')
-          expect(messages[0].html).not.toBeDefined()
-          expect(messages[0].text).toBe(message)
-          expect(messages[0].filePath).toBe(bitwisePath)
-          expect(messages[0].range).toEqual([[0, 10], [0, 13]])
-        })
-      )
-    })
-  })
+          expect(messages[0].type).toBe('Warning');
+          expect(messages[0].html).not.toBeDefined();
+          expect(messages[0].text).toBe(message);
+          expect(messages[0].filePath).toBe(bitwisePath);
+          expect(messages[0].range).toEqual([[0, 10], [0, 13]]);
+        }),
+      );
+    });
+  });
 
   it('finds nothing wrong with an empty file', () => {
     waitsForPromise(() =>
       atom.workspace.open(emptyPath).then(editor =>
         lint(editor).then((messages) => {
-          expect(messages.length).toBe(0)
-        })
-      )
-    )
-  })
+          expect(messages.length).toBe(0);
+        }),
+      ),
+    );
+  });
 
   it('finds nothing wrong with a valid file', () => {
     waitsForPromise(() =>
       atom.workspace.open(goodPath).then(editor =>
         lint(editor).then((messages) => {
-          expect(messages.length).toBe(0)
-        })
-      )
-    )
-  })
+          expect(messages.length).toBe(0);
+        }),
+      ),
+    );
+  });
 
   describe('shows syntax errors', () => {
-    let editor = null
+    let editor = null;
     beforeEach(() => {
       waitsForPromise(() =>
         atom.workspace.open(syntaxPath).then((openEditor) => {
-          editor = openEditor
-        })
-      )
-    })
+          editor = openEditor;
+        }),
+      );
+    });
 
     it('verifies the first message', () => {
-      const message = 'E006 - Unexpected early end of program.'
+      const message = 'E006 - Unexpected early end of program.';
       waitsForPromise(() =>
         lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('Error')
-          expect(messages[0].html).not.toBeDefined()
-          expect(messages[0].text).toBe(message)
-          expect(messages[0].filePath).toBe(syntaxPath)
-          expect(messages[0].range).toEqual([[0, 10], [0, 11]])
-        })
-      )
-    })
-  })
-})
+          expect(messages[0].type).toBe('Error');
+          expect(messages[0].html).not.toBeDefined();
+          expect(messages[0].text).toBe(message);
+          expect(messages[0].filePath).toBe(syntaxPath);
+          expect(messages[0].range).toEqual([[0, 10], [0, 11]]);
+        }),
+      );
+    });
+  });
+});

--- a/spec/linter-jshint-spec.js
+++ b/spec/linter-jshint-spec.js
@@ -57,7 +57,7 @@ describe('The JSHint provider for Linter', () => {
 
   it('finds nothing wrong with an empty file', () => {
     waitsForPromise(() =>
-      atom.workspace.open(emptyPath).then((editor) =>
+      atom.workspace.open(emptyPath).then(editor =>
         lint(editor).then((messages) => {
           expect(messages.length).toBe(0)
         })
@@ -67,7 +67,7 @@ describe('The JSHint provider for Linter', () => {
 
   it('finds nothing wrong with a valid file', () => {
     waitsForPromise(() =>
-      atom.workspace.open(goodPath).then((editor) =>
+      atom.workspace.open(goodPath).then(editor =>
         lint(editor).then((messages) => {
           expect(messages.length).toBe(0)
         })


### PR DESCRIPTION
Fixes the lint issues exposed, and updates the following to satisfy `peerDependencies`:
* `eslint@^3.12.0`
* `eslint-plugin-import@^2.2.0`

Also brings in a massive simplification of the rules, including removal of `babel-eslint` as it wasn't necessary here.

Closes #350.
Closes #355.