### PR TITLE
Async-ify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "eslint": "^3.12.0",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "flow-bin": "^0.45.0"
+    "flow-bin": "^0.45.0",
+    "jasmine-fix": "^1.0.1"
   },
   "eslintConfig": {
     "parser": "babel-eslint",

--- a/spec/linter-jshint-spec.js
+++ b/spec/linter-jshint-spec.js
@@ -1,26 +1,21 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import * as path from 'path';
 import linter from '../lib/main';
 
 const bitwisePath = path.join(__dirname, 'fixtures', 'bitwise', 'bitwise.js');
-const syntaxPath = path.join(__dirname, 'fixtures', 'syntax', 'badSyntax.js');
 const emptyPath = path.join(__dirname, 'fixtures', 'empty.js');
 const goodPath = path.join(__dirname, 'fixtures', 'good.js');
 
 describe('The JSHint provider for Linter', () => {
   const lint = linter.provideLinter().lint;
 
-  beforeEach(() => {
-    waitsForPromise(() =>
-      atom.packages.activatePackage('linter-jshint'),
-    );
-    waitsForPromise(() =>
-      atom.packages.activatePackage('language-javascript'),
-    );
-    waitsForPromise(() =>
-      atom.workspace.open(bitwisePath),
-    );
+  beforeEach(async () => {
+    await atom.packages.activatePackage('linter-jshint');
+    await atom.packages.activatePackage('language-javascript');
+    await atom.workspace.open(bitwisePath);
   });
 
   it('should be in the packages list', () =>
@@ -33,69 +28,51 @@ describe('The JSHint provider for Linter', () => {
 
   describe('shows errors in a file with issues', () => {
     let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open(bitwisePath).then((openEditor) => {
-          editor = openEditor;
-        }),
-      );
+
+    beforeEach(async () => {
+      editor = await atom.workspace.open(bitwisePath);
     });
 
-    it('verifies the first message', () => {
-      const message = "W016 - Unexpected use of '&'.";
-      waitsForPromise(() =>
-        lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('Warning');
-          expect(messages[0].html).not.toBeDefined();
-          expect(messages[0].text).toBe(message);
-          expect(messages[0].filePath).toBe(bitwisePath);
-          expect(messages[0].range).toEqual([[0, 10], [0, 13]]);
-        }),
-      );
+    it('verifies the first message', async () => {
+      const expected = "W016 - Unexpected use of '&'.";
+
+      const messages = await lint(editor);
+      expect(messages[0].type).toBe('Warning');
+      expect(messages[0].html).not.toBeDefined();
+      expect(messages[0].text).toBe(expected);
+      expect(messages[0].filePath).toBe(bitwisePath);
+      expect(messages[0].range).toEqual([[0, 10], [0, 13]]);
     });
   });
 
-  it('finds nothing wrong with an empty file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(emptyPath).then(editor =>
-        lint(editor).then((messages) => {
-          expect(messages.length).toBe(0);
-        }),
-      ),
-    );
+  it('finds nothing wrong with an empty file', async () => {
+    const editor = await atom.workspace.open(emptyPath);
+    const messages = await lint(editor);
+    expect(messages.length).toBe(0);
   });
 
-  it('finds nothing wrong with a valid file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(goodPath).then(editor =>
-        lint(editor).then((messages) => {
-          expect(messages.length).toBe(0);
-        }),
-      ),
-    );
+  it('finds nothing wrong with a valid file', async () => {
+    const editor = await atom.workspace.open(goodPath);
+    const messages = await lint(editor);
+    expect(messages.length).toBe(0);
   });
 
   describe('shows syntax errors', () => {
+    const syntaxPath = path.join(__dirname, 'fixtures', 'syntax', 'badSyntax.js');
     let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open(syntaxPath).then((openEditor) => {
-          editor = openEditor;
-        }),
-      );
+
+    beforeEach(async () => {
+      editor = await atom.workspace.open(syntaxPath);
     });
 
-    it('verifies the first message', () => {
+    it('verifies the first message', async () => {
       const message = 'E006 - Unexpected early end of program.';
-      waitsForPromise(() =>
-        lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('Error');
-          expect(messages[0].html).not.toBeDefined();
-          expect(messages[0].text).toBe(message);
-          expect(messages[0].filePath).toBe(syntaxPath);
-          expect(messages[0].range).toEqual([[0, 10], [0, 11]]);
-        }),
-      );
+      const messages = await lint(editor);
+      expect(messages[0].type).toBe('Error');
+      expect(messages[0].html).not.toBeDefined();
+      expect(messages[0].text).toBe(message);
+      expect(messages[0].filePath).toBe(syntaxPath);
+      expect(messages[0].range).toEqual([[0, 10], [0, 11]]);
     });
   });
 });


### PR DESCRIPTION
Greatly simplify the specs by bringing in the `jasmine-fix` module to allow using `async`/`await` in the specs.