### PR TITLE
Allow JSHint to handle configuration where possible

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,10 +1,13 @@
 'use babel';
 
 import path from 'path';
+import { homedir } from 'os';
 import * as atomlinter from 'atom-linter';
-import { readFile as fsReadFile } from 'fs';
+import { readFile as fsReadFile, access } from 'fs';
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import type { TextEditor } from 'atom';
+
+let homeConfigPath;
 
 async function readFile(filePath) {
   return new Promise((resolve, reject) => {
@@ -15,6 +18,24 @@ async function readFile(filePath) {
       resolve(data);
     });
   });
+}
+
+async function fileExists(checkPath) {
+  return new Promise((resolve) => {
+    access(checkPath, (err) => {
+      if (err) {
+        resolve(false);
+      }
+      resolve(true);
+    });
+  });
+}
+
+export async function hasHomeConfig() {
+  if (!homeConfigPath) {
+    homeConfigPath = path.join(homedir(), '.jshintrc');
+  }
+  return fileExists(homeConfigPath);
 }
 
 export async function readIgnoreList(ignorePath) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -122,9 +122,9 @@ module.exports = {
 
         const configFile = await atomlinter.findCachedAsync(fileDir, this.jshintFileName);
 
-        if (configFile) {
+        if (configFile && this.jshintFileName !== '.jshintrc') {
           parameters.push('--config', configFile);
-        } else if (this.disableWhenNoJshintrcFileInPath) {
+        } else if (this.disableWhenNoJshintrcFileInPath && !helpers.hasHomeConfig()) {
           return results;
         }
 


### PR DESCRIPTION
Use the configuration search only to determine whether or not we should call the full JSHint run, unless the user has specified a custom name for the file. If we don't find a file in the default "all parents" search, then check the user's home directory and the "disable when no config" setting to determine whether the lint run should continue.

Fixes #339.