### PR TITLE
Wait on home config check response

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -124,7 +124,7 @@ module.exports = {
 
         if (configFile && this.jshintFileName !== '.jshintrc') {
           parameters.push('--config', configFile);
-        } else if (this.disableWhenNoJshintrcFileInPath && !helpers.hasHomeConfig()) {
+        } else if (this.disableWhenNoJshintrcFileInPath && !(await helpers.hasHomeConfig())) {
           return results;
         }
 


### PR DESCRIPTION
Properly wait on the response from the check as to whether the user has a configuration in their home directory.

Fixes #391.