### PR TITLE
Fix logic when there is a config file

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -122,8 +122,10 @@ module.exports = {
 
         const configFile = await atomlinter.findCachedAsync(fileDir, this.jshintFileName);
 
-        if (configFile && this.jshintFileName !== '.jshintrc') {
-          parameters.push('--config', configFile);
+        if (configFile) {
+          if (this.jshintFileName !== '.jshintrc') {
+            parameters.push('--config', configFile);
+          }
         } else if (this.disableWhenNoJshintrcFileInPath && !(await helpers.hasHomeConfig())) {
           return results;
         }


### PR DESCRIPTION
If there was a config file and the name _hadn't_ been customized, the old logic would then disable linting if hte user _didn't_ have a configuration in their home directory. Split the config file check and the check for a custom name apart to fix this.

Fixes #396.