### PR TITLE
Specify a minimum Atom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
       "browser": true
     }
   },
+  "engines": {
+    "atom": ">=1.7.0 <2.0.0"
+  },
   "providedServices": {
     "linter": {
       "versions": {


### PR DESCRIPTION
Specifies the mimimum Atom version to be v1.7.0 for `requestIdleCallback` support, as well as the maximum Atom version to be "below v2".

Fixes #402.