### PR TITLE
Fix Atom Beta Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,10 @@ dist: trusty
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
The latest Atom beta builds require some further changes to the configuration of Travis CI.