### PR TITLE
Fix generation of invalid trace messages

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -88,7 +88,7 @@ export async function generateDebugString() {
   const debug = await getDebugInfo();
   const details = [
     `Atom version: ${debug.atomVersion}`,
-    `linter-jshint version: ${debug.linterJSHintVersion}`,
+    `linter-jshint version: v${debug.linterJSHintVersion}`,
     `JSHint version: ${debug.jshintVersion}`,
     `Hours since last Atom restart: ${debug.hoursSinceRestart}`,
     `Platform: ${debug.platform}`,
@@ -99,12 +99,12 @@ export async function generateDebugString() {
 }
 
 export async function generateInvalidTrace(
-  msgLine: number, msgCol: number, filePath: string, textEditor: TextEditor,
+  msgLine: number, msgCol: number, file: string, textEditor: TextEditor,
   error: Object,
 ) {
   const errMsgRange = `${msgLine + 1}:${msgCol}`;
   const rangeText = `Requested start point: ${errMsgRange}`;
-  const issueURL = 'https://github.com/AtomLinter/linter-eslint/issues/new';
+  const issueURL = 'https://github.com/AtomLinter/linter-jshint/issues/new';
   const titleText = `Invalid position given by '${error.code}'`;
   const title = encodeURIComponent(titleText);
   const body = encodeURIComponent([
@@ -115,8 +115,8 @@ export async function generateInvalidTrace(
     '<!-- If at all possible, please include code to reproduce this issue! -->',
     '', '',
     'Debug information:',
-    '```json',
-    JSON.stringify(await getDebugInfo(), null, 2),
+    '```',
+    await generateDebugString(),
     '```',
   ].join('\n'));
   const newIssueURL = `${issueURL}?title=${title}&body=${body}`;
@@ -126,7 +126,7 @@ export async function generateInvalidTrace(
     detils: `Original message: ${error.code} - ${error.reason}`,
     url: newIssueURL,
     location: {
-      filePath,
+      file,
       position: atomlinter.generateRange(textEditor),
     },
   };

--- a/lib/main.js
+++ b/lib/main.js
@@ -175,7 +175,7 @@ module.exports = {
           return results;
         }
 
-        Object.keys(parsed.result).forEach(async (entryID) => {
+        Object.keys(parsed.result).forEach((entryID) => {
           let message;
           const entry = parsed.result[entryID];
 
@@ -200,13 +200,15 @@ module.exports = {
               },
             };
           } catch (e) {
-            message = await helpers.generateInvalidTrace(
+            message = helpers.generateInvalidTrace(
               line, character, filePath, textEditor, error);
           }
 
           results.push(message);
         });
-        return results;
+
+        // Make sure any invalid traces have resolved
+        return Promise.all(results);
       },
     };
   },


### PR DESCRIPTION
`await`ing on the message generation in the loop like that doesn't work, we need to wait on the results as a whole to ensure those have resolved.

Also fixes a few issues with the invalid messages themselves.

Fixes #416.