### PR TITLE
Cache debug information where possible

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,6 +8,7 @@ import { readFile as fsReadFile, access } from 'fs';
 import type { TextEditor } from 'atom';
 
 let homeConfigPath;
+const debugCache = new Map();
 
 async function readFile(filePath) {
   return new Promise((resolve, reject) => {
@@ -42,14 +43,9 @@ export async function readIgnoreList(ignorePath) {
   return (await readFile(ignorePath)).split(/[\r\n]/);
 }
 
-export async function getDebugInfo() {
-  const textEditor = atom.workspace.getActiveTextEditor();
-  let editorScopes;
-  if (atom.workspace.isTextEditor(textEditor)) {
-    editorScopes = textEditor.getLastCursor().getScopeDescriptor().getScopesArray();
-  } else {
-    // Somehow this can be called with no active TextEditor, impossible I know...
-    editorScopes = ['unknown'];
+async function getPackageVersion() {
+  if (debugCache.has('packageVersion')) {
+    return debugCache.get('packageVersion');
   }
 
   const packagePath = atom.packages.resolvePackagePath('linter-jshint');
@@ -63,25 +59,53 @@ export async function getDebugInfo() {
     linterJSHintMeta = JSON.parse(await readFile(metaPath));
   }
 
-  const config = atom.config.get('linter-jshint');
-  const hoursSinceRestart = Math.round((process.uptime() / 3600) * 10) / 10;
+  debugCache.set('packageVersion', linterJSHintMeta.version);
+  return linterJSHintMeta.version;
+}
+
+async function getJSHintVersion(config) {
   const execPath = config.executablePath !== '' ? config.executablePath :
     path.join(__dirname, '..', 'node_modules', 'jshint', 'bin', 'jshint');
+
+  if (debugCache.has(execPath)) {
+    return debugCache.get(execPath);
+  }
+
   // NOTE: Yes, `jshint --version` gets output on STDERR...
   const jshintVersion = await atomlinter.execNode(
-      execPath, ['--version'], { stream: 'stderr' });
+    execPath, ['--version'], { stream: 'stderr' });
+  debugCache.set(execPath, jshintVersion);
+  return jshintVersion;
+}
 
-  const returnVal = {
+function getEditorScopes() {
+  const textEditor = atom.workspace.getActiveTextEditor();
+  let editorScopes: Array<string>;
+  if (atom.workspace.isTextEditor(textEditor)) {
+    editorScopes = textEditor.getLastCursor().getScopeDescriptor().getScopesArray();
+  } else {
+    // Somehow this can be called with no active TextEditor, impossible I know...
+    editorScopes = ['unknown'];
+  }
+  return editorScopes;
+}
+
+export async function getDebugInfo() {
+  const linterJSHintVersion = await getPackageVersion();
+  const config = atom.config.get('linter-jshint');
+  const jshintVersion = await getJSHintVersion(config);
+  const hoursSinceRestart = Math.round((process.uptime() / 3600) * 10) / 10;
+  const editorScopes = getEditorScopes();
+
+  return {
     atomVersion: atom.getVersion(),
-    linterJSHintVersion: linterJSHintMeta.version,
+    linterJSHintVersion,
     linterJSHintConfig: config,
-    // eslint-disable-next-line import/no-dynamic-require
     jshintVersion,
     hoursSinceRestart,
     platform: process.platform,
     editorScopes,
   };
-  return returnVal;
 }
 
 export async function generateDebugString() {


### PR DESCRIPTION
Where possible the debug information is now cached between requests:
* JSHint version calls now only happen once per executable path
* Package version determination is only done once

Fixes #410.