### PR TITLE
Remove some Travis CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,8 @@ dist: trusty
 
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
     packages:
-    - g++-6
+    - build-essential
     - fakeroot
     - git
     - libsecret-1-dev


### PR DESCRIPTION
Atom v1.19.0-beta2 removed the requirement on the newer GLIBCXX so we can remove the extra work required to support it.