### PR TITLE
Check for existing issues

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -43,24 +43,12 @@ export async function readIgnoreList(ignorePath) {
   return (await readFile(ignorePath)).split(/[\r\n]/);
 }
 
-async function getPackageVersion() {
-  if (debugCache.has('packageVersion')) {
-    return debugCache.get('packageVersion');
-  }
-
-  const packagePath = atom.packages.resolvePackagePath('linter-jshint');
-  let linterJSHintMeta;
-  if (packagePath === undefined) {
-    // Apparently for some users the package path fails to resolve
-    linterJSHintMeta = { version: 'unknown!' };
-  } else {
-    // eslint-disable-next-line import/no-dynamic-require
-    const metaPath = path.join(packagePath, 'package.json');
-    linterJSHintMeta = JSON.parse(await readFile(metaPath));
-  }
-
-  debugCache.set('packageVersion', linterJSHintMeta.version);
-  return linterJSHintMeta.version;
+function getPackageMeta() {
+  // NOTE: This is using a non-public property of the Package object
+  // The alternative to this would basically mean re-implementing the parsing
+  // that Atom is already doing anyway, and as this is unlikely to change this
+  // is likely safe to use.
+  return atom.packages.getLoadedPackage('linter-jshint').metadata;
 }
 
 async function getJSHintVersion(config) {
@@ -91,7 +79,7 @@ function getEditorScopes() {
 }
 
 export async function getDebugInfo() {
-  const linterJSHintVersion = await getPackageVersion();
+  const linterJSHintVersion = getPackageMeta().version;
   const config = atom.config.get('linter-jshint');
   const jshintVersion = await getJSHintVersion(config);
   const hoursSinceRestart = Math.round((process.uptime() / 3600) * 10) / 10;
@@ -122,14 +110,86 @@ export async function generateDebugString() {
   return details.join('\n');
 }
 
+/**
+ * Finds the oldest open issue of the same title in this project's repository.
+ * Results are cached for 1 hour.
+ * @param  {string} issueTitle The issue title to search for
+ * @return {string|null}       The URL of the found issue or null if none is found.
+ */
+async function findSimilarIssue(issueTitle) {
+  if (debugCache.has(issueTitle)) {
+    const oldResult = debugCache.get(issueTitle);
+    if ((new Date().valueOf()) < oldResult.expires) {
+      return oldResult.url;
+    }
+    debugCache.delete(issueTitle);
+  }
+
+  const oneHour = 1000 * 60 * 60; // ms * s * m
+  const tenMinutes = 1000 * 60 * 10; // ms * s * m
+  const repoUrl = getPackageMeta().repository.url;
+  const repo = repoUrl.replace(/https?:\/\/(\d+\.)?github\.com\//gi, '');
+  const query = encodeURIComponent(`repo:${repo} is:open in:title ${issueTitle}`);
+  const githubHeaders = new Headers({
+    accept: 'application/vnd.github.v3+json',
+    contentType: 'application/json',
+  });
+  const queryUrl = `https://api.github.com/search/issues?q=${query}&sort=created&order=asc`;
+
+  let url = null;
+  try {
+    const rawResponse = await fetch(queryUrl, { headers: githubHeaders });
+    if (!rawResponse.ok) {
+      // Querying GitHub API failed, don't try again for 10 minutes.
+      debugCache.set(issueTitle, {
+        expires: (new Date().valueOf()) + tenMinutes,
+        url,
+      });
+      return null;
+    }
+    const data = await rawResponse.json();
+    if ((data !== null ? data.items : null) !== null) {
+      if (Array.isArray(data.items) && data.items.length > 0) {
+        const issue = data.items[0];
+        if (issue.title.includes(issueTitle)) {
+          url = `${repoUrl}/issues/${issue.number}`;
+        }
+      }
+    }
+  } catch (e) {
+    // Do nothing
+  }
+  debugCache.set(issueTitle, {
+    expires: (new Date().valueOf()) + oneHour,
+    url,
+  });
+  return url;
+}
+
 export async function generateInvalidTrace(
   msgLine: number, msgCol: number, file: string, textEditor: TextEditor,
   error: Object,
 ) {
   const errMsgRange = `${msgLine + 1}:${msgCol}`;
-  const rangeText = `Requested start point: ${errMsgRange}`;
-  const issueURL = 'https://github.com/AtomLinter/linter-jshint/issues/new';
+  const rangeText = `Requested point: ${errMsgRange}`;
+  const packageRepoUrl = getPackageMeta().repository.url;
+  const issueURL = `${packageRepoUrl}/issues/new`;
   const titleText = `Invalid position given by '${error.code}'`;
+  const invalidMessage = {
+    severity: 'error',
+    description: `Original message: ${error.code} - ${error.reason}  \n${rangeText}.`,
+    location: {
+      file,
+      position: atomlinter.generateRange(textEditor),
+    },
+  };
+  const similarIssueUrl = await findSimilarIssue(titleText);
+  if (similarIssueUrl !== null) {
+    invalidMessage.excerpt = `${titleText}. This has already been reported, see message link!`;
+    invalidMessage.url = similarIssueUrl;
+    return invalidMessage;
+  }
+
   const title = encodeURIComponent(titleText);
   const body = encodeURIComponent([
     'JSHint returned a point that did not exist in the document being edited.',
@@ -144,14 +204,7 @@ export async function generateInvalidTrace(
     '```',
   ].join('\n'));
   const newIssueURL = `${issueURL}?title=${title}&body=${body}`;
-  return {
-    severity: 'error',
-    excerpt: `${titleText}. ${rangeText}. Please report this using the message link!`,
-    detils: `Original message: ${error.code} - ${error.reason}`,
-    url: newIssueURL,
-    location: {
-      file,
-      position: atomlinter.generateRange(textEditor),
-    },
-  };
+  invalidMessage.excerpt = `${titleText}. Please report this using the message link!`;
+  invalidMessage.url = newIssueURL;
+  return invalidMessage;
 }


### PR DESCRIPTION
When an invalid point is encountered instead of always reporting a new issue, check GitHub for any existing open issues first. If any are found link the user there instead.

Results are cached for an hour to prevent spamming the API.