### PR TITLE
Use .jshintignore path as root for relative paths

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,15 +23,15 @@ const readFile = async filePath =>
   });
 
 export const isIgnored = async (filePath, ignorePath) => {
-  const fileDir = path.dirname(filePath);
+  const ignoreDir = path.dirname(ignorePath);
   const rawIgnoreList = (await readFile(ignorePath)).split(/[\r\n]/);
 
   // "Fix" the patterns in the same way JSHint does
   const ignoreList = rawIgnoreList.filter(line => !!line.trim()).map((pattern) => {
     if (pattern.startsWith('!')) {
-      return `!${path.resolve(fileDir, pattern.substr(1).trim())}`;
+      return `!${path.resolve(ignoreDir, pattern.substr(1).trim())}`;
     }
-    return path.join(fileDir, pattern.trim());
+    return path.join(ignoreDir, pattern.trim());
   });
 
   // Check the modified patterns

--- a/spec/linter-jshint-spec.js
+++ b/spec/linter-jshint-spec.js
@@ -91,13 +91,14 @@ describe('The JSHint provider for Linter', () => {
   });
 
   describe('handles .jshintignore files', () => {
-    const checkMessage = (message, filePath) => {
+    const checkMessages = (messages, filePath) => {
       const expected = "W098 - 'foo' is defined but never used.";
 
-      expect(message.severity).toBe('warning');
-      expect(message.excerpt).toBe(expected);
-      expect(message.location.file).toBe(filePath);
-      expect(message.location.position).toEqual([[0, 4], [0, 7]]);
+      expect(messages.length).toBe(1);
+      expect(messages[0].severity).toBe('warning');
+      expect(messages[0].excerpt).toBe(expected);
+      expect(messages[0].location.file).toBe(filePath);
+      expect(messages[0].location.position).toEqual([[0, 4], [0, 7]]);
     };
 
     it('works when in the same directory', async () => {
@@ -106,11 +107,10 @@ describe('The JSHint provider for Linter', () => {
       const ignoredPath = path.join(ignoreDir, 'ignored.js');
       const checkEditor = await atom.workspace.open(checkedPath);
       const ignoreEditor = await atom.workspace.open(ignoredPath);
-      const checkMessages = await lint(checkEditor);
+      const checkedMessages = await lint(checkEditor);
       const ignoreMessages = await lint(ignoreEditor);
 
-      expect(checkMessages.length).toBe(1);
-      checkMessage(checkMessages[0], checkedPath);
+      checkMessages(checkedMessages, checkedPath);
 
       expect(ignoreMessages.length).toBe(0);
     });
@@ -121,11 +121,10 @@ describe('The JSHint provider for Linter', () => {
       const ignoredPath = path.join(ignoreDir, 'ignored.js');
       const checkEditor = await atom.workspace.open(checkedPath);
       const ignoreEditor = await atom.workspace.open(ignoredPath);
-      const checkMessages = await lint(checkEditor);
+      const checkedMessages = await lint(checkEditor);
       const ignoreMessages = await lint(ignoreEditor);
 
-      expect(checkMessages.length).toBe(1);
-      checkMessage(checkMessages[0], checkedPath);
+      checkMessages(checkedMessages, checkedPath);
 
       expect(ignoreMessages.length).toBe(0);
     });


### PR DESCRIPTION
When parsing paths from the `.jshintignore` file, use the directory of the `.jshintignore` file as the root for the paths, not the directory of the file being linted.

Fixes #514.