### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,42 @@
 ### Project specific config ###
 language: node_js
+node_js: lts/*
+install: skip
+os: linux
 
-matrix:
+jobs:
   include:
-    - os: linux
+    # Test Atom versions
+    - stage: test
       env: ATOM_CHANNEL=stable
-      node_js: "node"
-
-    - os: linux
+    - stage: test
       env: ATOM_CHANNEL=beta
-      node_js: "node"
+
+    # Check the commit messages and run the extra lint script
+    - stage: test
+      install:
+        - npm install
+      before_script: skip
+      script:
+        - commitlint-travis
+        - npm run lint
+
+    - stage: release
+      # Since the deploy needs APM, currently the simplest method is to run
+      # build-package.sh, which requires the specs to pass.
+      before_deploy:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - npx semantic-release
 
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
-  - npm run lint
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -26,6 +46,7 @@ notifications:
 branches:
   only:
     - master
+    - "/^greenkeeper/.*$/"
 
 git:
   depth: 10
@@ -38,18 +59,11 @@ addons:
   apt:
     packages:
     - build-essential
-    - fakeroot
     - git
-    - libsecret-1-dev
+    - libgnome-keyring-dev
+    - fakeroot
 
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,15 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "main": "./lib/main.js",
   "version": "3.1.6",
   "description": "Linter plugin for JavaScript, using jshint",
-  "repository": "https://github.com/AtomLinter/linter-jshint.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-jshint.git"
+  },
   "license": "MIT",
   "configSchema": {
     "executablePath": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     }
   },
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "test": "apm test",
     "lint": "eslint lib spec decls && flow check"
   },
@@ -56,6 +57,12 @@
     "shelljs": "^0.8.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "babel-eslint": "^8.0.0",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
@@ -94,5 +101,13 @@
         "2.0.0": "provideLinter"
       }
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
