### PR TITLE
Update to the Xenial based image on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ git:
 
 sudo: false
 
-dist: trusty
+dist: xenial
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+    - libgconf-2-4
 
 stages:
   - test


### PR DESCRIPTION
Atom's current beta build throws a warning on older versions of the `libdbus-1.so.3` library... which the `trusty` based distribution just happens to be using. Although this warning doesn't prevent Atom itself from working, it causes `stderr` output from the calls to `jshint`, which makes it look like it has failed.

Also forces the installation of libgconf-2-4 for stable Atom since it doesn't currently mark that as required.